### PR TITLE
Feature 11 API Endpoint for reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Parameters:
 | url_two        | The URL of the original post                                        |
 
 
+## GET `/posts/pending`
+
+Returns a list of pending posts which have no feedback. 
+
+    { "posts": [ 1, 2, 3], "status": "success"}
+
 ## GET `/posts/<post_id>`
 
 A web view of the two posts next to each other. Error code 410 for deleted reports and 404 for non available reports.

--- a/copypasta.py
+++ b/copypasta.py
@@ -17,7 +17,7 @@ def page_not_found(error):
 @app.errorhandler(500)
 def internal_server_error(error):
     print(error)
-    return render_template('error.html', message="Umph! Something bad happened, we'll look into it. Thanks ... (testing webhooks)"), 500
+    return render_template('error.html', message="Umph! Something bad happened, we'll look into it. Thanks ..."), 500
 
 
 @app.route("/")
@@ -102,6 +102,12 @@ def get_post(post_id):
     except KeyError as e:
         print(e)
         return render_template('error.html', message="Sorry, the post has been deleted ..."), 410
+
+
+@app.route("/posts/pending", methods=['GET'])
+def get_pending():
+    posts = fetch_posts_without_feedback()
+    return jsonify({"status": "success", "posts": posts})
 
 
 def get_body(body):
@@ -218,3 +224,13 @@ def check_for_auth(data):
         if row is None:
             return False
         return True
+
+
+def fetch_posts_without_feedback():
+    with app.app_context():
+        cur = get_db().cursor()
+        cur.execute("select post_id from posts where post_id not in (select post_id from feedback);")
+        posts = cur.fetchall()
+        if posts:
+            return [i[0] for i in posts]
+        return posts


### PR DESCRIPTION
I've added a GET endpoint `/posts/pending`, which would return those posts which have no feedback.  

Closes https://github.com/SOBotics/CopyPastor/issues/11 