### PR TITLE
Fixed the side by side view, and made the inline view default

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1,3 +1,5 @@
+// code taken from the example mentioned here https://github.com/kpdecker/jsdiff
+
 function disp(one, other)
 {
 
@@ -24,4 +26,49 @@ diff.forEach(function(part){
 });
 
 display.appendChild(fragment);
+}
+
+function disp_sbs(one, other)
+{
+
+one.replace("<//script>", "</script>")
+other.replace("<//script>", "</script>")
+
+var color = '',
+    span = null;
+
+var diff = JsDiff.diffWords(one, other),
+    left = document.getElementById('left'),
+    right = document.getElementById('right'),
+    left_fragment = document.createDocumentFragment(),
+    right_fragment = document.createDocumentFragment();
+
+diff.forEach(function(part){
+  // green for additions, red for deletions
+  // grey for common parts
+  color = part.added ? 'black' :
+    part.removed ? 'green' : 'red';
+  span = document.createElement('span');
+  span.style.color = color;
+  span.appendChild(document
+    .createTextNode(part.value));
+
+  switch(color){
+
+    case 'red'  : span_clone = span.cloneNode(true)
+                  left_fragment.appendChild(span);
+                  right_fragment.appendChild(span_clone);
+                  break;
+
+    case 'black': right_fragment.appendChild(span);
+                  break;
+
+    case 'green': left_fragment.appendChild(span);
+                  break;
+  }
+
+});
+
+left.appendChild(left_fragment);
+right.appendChild(right_fragment);
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,8 +7,9 @@
 .textcat{height: 1.5em;}
 .headimg{float:right;width:7%; max-width:100px;}
 .openall{float:right;color:#007bff;cursor:pointer;font-weight:bold;}
-.display-switcher{float:right;padding-right:10px}
+.display-switcher{float:right;padding-right:10px;cursor:pointer;}
 .bar{height:20px;display:inline-block}
 .stats{border-radius:3px}
 .sd{white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space:-o-pre-wrap;word-wrap:break-word;}
 .sd>span{font-size:13px}
+.deprecated{color:#b8bbc1;}

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,6 @@
 <script src="{{ url_for('static', filename='diff.js') }}"></script>
 <script src="{{ url_for('static', filename='scripts.js') }}"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js"></script>
-<script type="text/javascript">function o(l1,l2){window.open(l1);window.open(l2)}; disp(`{{f_body_one|safe}}`,`{{f_body_two|safe}}`); $('#single').hide();</script>
+<script type="text/javascript">function o(l1,l2){window.open(l1);window.open(l2)}; disp(`{{f_body_one|safe}}`,`{{f_body_two|safe}}`); disp_sbs(`{{f_body_one|safe}}`,`{{f_body_two|safe}}`); $('#double').hide(); $('#old').hide();</script>
 </body>
 </html>

--- a/templates/render.html
+++ b/templates/render.html
@@ -8,8 +8,15 @@
             <span class="fa fa-external-link" style="color:grey"></span>
         </span>
         <span class="display-switcher">
-            <span onclick="$('#double').show();$('#single').hide();"><i class="fas fa-columns"></i></span>
-            <span onclick="$('#single').show();$('#double').hide();"><i class="fas fa-align-justify"></i></span>
+            <span onclick="$('#single').show();$('#double').hide();$('#old').hide();" title="Inline View">
+                <i class="fas fa-align-justify"></i>
+            </span>
+            <span onclick="$('#double').show();$('#single').hide();$('#old').hide();" title="Side By Side View">
+                <i class="fas fa-columns"></i>
+            </span>
+            <span onclick="$('#old').show();$('#single').hide();$('#double').hide();" title="Side By Side Old View (Line matching)">
+                <i class="fas fa-columns deprecated"></i>
+            </span>
         </span>
     </div>
 
@@ -52,6 +59,22 @@
     </div>
     <br>
     <div class="container" id="double">
+        <div class="row">
+            <div class="col">
+                <pre class="cd sd" id="left"></pre>
+            </div>
+            <div class="col">
+                <pre class="cd sd" id="right"></pre>
+            </div>
+        </div>
+        <div class="legend" title="Legend">
+            <span style="color:red">Present in both answers;</span>
+            <span style="color:green">Present only in the new answer;</span>
+            <span style="color:black">Present only in the old answer;</span>
+        </div>
+    </div>
+    <br>
+    <div class="container" id="old">
         <div class="row">
             <div class="col">
                 <div class="cd">


### PR DESCRIPTION
The switcher now defaults to the inline view, and has two side-by-side views. The greyed out one is the old one, which still is a line by line comparison. The new one looks like this: 

<img width="1157" alt="screen shot 2019-01-04 at 5 13 58 am" src="https://user-images.githubusercontent.com/10547506/50689698-9a28ce80-0fdf-11e9-854f-9b7007793ae4.png">

