### PR TITLE
Show if a post is deleted to make flagging easier

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -72,3 +72,22 @@ diff.forEach(function(part){
 left.appendChild(left_fragment);
 right.appendChild(right_fragment);
 }
+
+
+// add (deleted) if a post has been deleted
+const apiKey = 'YNIhT*kUiXt*Rp*pDBTBnA((';
+const filter = '!-.HCX)kdt*(H';
+const sitename = 'stackoverflow';
+const apiUrl = 'https://api.stackexchange.com/2.2/posts/';
+const plagiarisedPostAnchor = document.querySelector('h2 a');
+const plagiarisedPostId = plagiarisedPostAnchor.href.split('/')[4];
+const originalPostAnchor = document.querySelectorAll('h2 a')[1];
+const originalPostId = originalPostAnchor.href.split('/')[4];
+const postIds = `${plagiarisedPostId};${originalPostId}`;
+const deletedSpan = ' <span class="text-danger">(deleted)</span>';
+
+fetch(`${apiUrl}${postIds}?site=${sitename}&filter=${filter}&key=${apiKey}`).then(response => response.json()).then(jsonResponse => {
+    const findPostId = id => jsonResponse.items.find(item => item.post_id == id);
+    if (!findPostId(plagiarisedPostId)) plagiarisedPostAnchor.parentElement.insertAdjacentHTML('afterend', deletedSpan);
+    if (!findPostId(originalPostId)) originalPostAnchor.parentElement.insertAdjacentHTML('afterend', deletedSpan);
+})


### PR DESCRIPTION
Appends `(deleted)` at the title of the post. Helpful when one wants to flag posts, but has to open them first to see if they are deleted.