### PR TITLE
Allow multiple targets for /posts/findTarget and add repost and feedbacks fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>0.12.2
+validators>0.18.1


### PR DESCRIPTION
Backwards-compatible change. I implemented it mostly to avoid making multiple requests with AF (one to `/posts/findTarget` and one to `/posts/{id}` per answer)